### PR TITLE
Specify a commit hash for the jsdoc-baseline package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-prettier": "^3.0.0",
     "gts": "^0.9.0",
     "jsdoc": "^3.5.5",
-    "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
+    "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git#222e13a",
     "linkinator": "^1.1.2",
     "mkdirp": "^0.5.1",
     "mocha": "^6.0.0",


### PR DESCRIPTION
I plan to make breaking changes to the hegemonic/jsdoc-baseline repo. To ensure that your repo is not affected by these breaking changes, this pull request pins the `jsdoc-baseline` package to a specific commit hash.

If you prefer, you can use the [NPM release of this package](https://www.npmjs.com/package/jsdoc-baseline) instead by setting the `jsdoc-baseline` property to `^0.1.1`.